### PR TITLE
Allow run flags that start with -

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -17,6 +17,7 @@ var runCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(runCmd)
+	runCmd.Flags().SetInterspersed(false)
 }
 
 func runRun(cmd *cobra.Command, args []string) {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -17,6 +17,7 @@ var testCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(testCmd)
+	testCmd.Flags().SetInterspersed(false)
 }
 
 func runTest(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Without this PR Cobra tries to parse all flags (every command-line argument that starts with -). This PR disables interspersed flag parsing for the "run" and "test" commands.
See also https://github.com/spf13/cobra/issues/352