### PR TITLE
Updated to complete using part of the target name and absolute paths.

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -415,13 +415,14 @@ func completeBuildArgs(toComplete string, mode mode) []string {
 	suggestions := []string{}
 	targetToComplete := normalizeTarget(toComplete)
 	for name, target := range genOutput.Targets {
-		if !strings.HasPrefix(name, targetToComplete) {
-			continue
-		}
 		if skipTarget(mode, target) {
 			continue
 		}
-		suggestions = append(suggestions, fmt.Sprintf("%s%s\t%s", toComplete, strings.TrimPrefix(name, targetToComplete), target.Description))
+		if strings.Contains(name, toComplete) {
+			suggestions = append(suggestions, fmt.Sprintf("//%s\t%s", name, target.Description))
+		} else if strings.HasPrefix(name, targetToComplete) {
+			suggestions = append(suggestions, fmt.Sprintf("%s%s\t%s", toComplete, strings.TrimPrefix(name, targetToComplete), target.Description))
+		}
 	}
 
 	for name, flag := range genOutput.Flags {

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"sort"
 	"strings"
@@ -658,4 +659,15 @@ func skipTarget(mode mode, target target) bool {
 		return !target.Testable && !target.Report
 	}
 	return false
+}
+
+func sortMapKeys(m interface{}) []string {
+	keys := reflect.ValueOf(m).MapKeys()
+	keyList := []string{}
+
+	for _, key := range keys {
+		keyList = append(keyList, key.Interface().(string))
+	}
+	sort.Strings(keyList)
+	return keyList
 }


### PR DESCRIPTION
The purpose of this PR is to make the completion functionality a bit smarter, and able to complete build targets based only on part of the name. If you have build targets such as:

```
  //exp-compute/hw/ipp/hdl/IppSynth
  //exp-compute/hw/ipp/hdl/Lint
  //exp-compute/hw/ipp/sim/Simulation
```

With this work as a user one can do e.g.

```
$ dbt build ipp
```
and hit tab which will replace your command line with
```
$ dbt build //exp-compute/hw/ipp/
```
and show the options of the three actual targets.