### PR TITLE
Add configuration for local mirror

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,79 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/daedaleanai/dbt/log"
+	"github.com/daedaleanai/dbt/util"
+	"gopkg.in/yaml.v2"
+)
+
+type Config struct {
+	Mirror string
+}
+
+var environment map[string]string
+var config *Config
+
+const configFileName string = "config.yaml"
+
+func init() {
+	environment = make(map[string]string)
+	for _, v := range os.Environ() {
+		parts := strings.Split(v, "=")
+		if len(parts) == 2 {
+			key := parts[0]
+			value := parts[1]
+			environment[key] = value
+		}
+	}
+}
+
+func getDbtConfigDir() (string, error) {
+	if dbtConfigDir, ok := environment["DBT_CONFIG_DIR"]; ok {
+		return dbtConfigDir, nil
+	}
+
+	if xdgConfigHome, ok := environment["XDG_CONFIG_HOME"]; ok {
+		return path.Join(xdgConfigHome, "dbt"), nil
+	}
+
+	if homeDir, ok := environment["HOME"]; ok {
+		return path.Join(path.Join(homeDir, ".config"), "dbt"), nil
+	}
+
+	return "", fmt.Errorf("Unable to locate the configuration directory")
+}
+
+func loadConfiguration() Config {
+	var config Config
+
+	configDir, err := getDbtConfigDir()
+	if err != nil {
+		log.Debug("Unable to find dbt config directory. Using default configuration\n")
+		return config
+	}
+
+	configFilePath := path.Join(configDir, configFileName)
+	err := yaml.Unmarshal(util.ReadFile(configFilePath), &config)
+	if err != nil {
+		log.Debug("Error reading configuration file at `%s`: `%s`. Using default configuration\n", configFilePath, err)
+		return config
+	}
+
+	log.Debug("Loaded configuration from `%s`\n", configFilePath)
+	log.Debug("Running with configuration: %+v\n", config)
+	return config
+}
+
+func GetConfig() Config {
+	if config == nil {
+		loadedConfig := loadConfiguration()
+		config = &loadedConfig
+	}
+
+	return *config
+}

--- a/config/config.go
+++ b/config/config.go
@@ -2,12 +2,12 @@ package config
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path"
 	"strings"
 
 	"github.com/daedaleanai/dbt/log"
-	"github.com/daedaleanai/dbt/util"
 	"gopkg.in/yaml.v2"
 )
 
@@ -58,7 +58,13 @@ func loadConfiguration() Config {
 	}
 
 	configFilePath := path.Join(configDir, configFileName)
-	err := yaml.Unmarshal(util.ReadFile(configFilePath), &config)
+	configFileData, err := ioutil.ReadFile(configFilePath)
+	if err != nil {
+		log.Debug("Failed to read file '%s': %s.\n", configFilePath, err.Error())
+		return config
+	}
+
+	err = yaml.Unmarshal(configFileData, &config)
 	if err != nil {
 		log.Debug("Error reading configuration file at `%s`: `%s`. Using default configuration\n", configFilePath, err)
 		return config

--- a/module/module.go
+++ b/module/module.go
@@ -301,12 +301,16 @@ func OpenModule(modulePath string) Module {
 
 	if util.DirExists(path.Join(modulePath, ".git")) {
 		log.Debug("Found '.git' directory. Expecting this to be a GitModule.\n")
-		return GitModule{modulePath}
+		module := GitModule{path: modulePath}
+		mirror, _ := getOrCreateGitMirror(module.URL())
+		return GitModule{path: modulePath, mirror: mirror}
 	}
 
 	if util.FileExists(path.Join(modulePath, tarMetadataFileName)) {
 		log.Debug("Found '%s' file. Expecting this to be a TarModule.\n", tarMetadataFileName)
-		return TarModule{modulePath}
+		module := TarModule{path: modulePath}
+		mirror, _ := getOrCreateTarMirror(module.URL())
+		return TarModule{path: modulePath, mirror: mirror}
 	}
 
 	log.Fatal("Module appears to be broken. Remove the module directory and rerun 'dbt sync'.\n")
@@ -326,7 +330,7 @@ func OpenOrCreateModule(modulePath string, url string) Module {
 
 	if strings.HasSuffix(url, ".git") {
 		log.Debug("Module URL ends in '.git'. Trying to create a new git module.\n")
-		module, err := createGitModule(modulePath, url)
+		module, err := CreateGitModule(modulePath, url)
 		if err != nil {
 			os.RemoveAll(modulePath)
 			log.Fatal("Failed to create git module: %s.\n", err)

--- a/module/tar.go
+++ b/module/tar.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/daedaleanai/dbt/config"
 	"github.com/daedaleanai/dbt/log"
 	"github.com/daedaleanai/dbt/util"
 )
@@ -28,6 +29,11 @@ type metadataFile struct {
 // TarModule is a module backed by a tar.gz archive.
 // TarModules only have a single "master" version.
 type TarModule struct {
+	path   string
+	mirror *TarMirror
+}
+
+type TarMirror struct {
 	path string
 }
 
@@ -48,111 +54,54 @@ func stripRoot(p string) string {
 	return p[len(root):]
 }
 
+// Obtains a mirror for a tar module if the global mirror directory has been set up
+func getOrCreateTarMirror(url string) (*TarMirror, error) {
+	configuration := config.GetConfig()
+	if configuration.Mirror == "" {
+		log.Debug("Mirrors are not configured.\n")
+		return nil, nil
+	}
+
+	urlHash := sha256.Sum256([]byte(url))
+	urlHashString := fmt.Sprintf("tar-%x", urlHash[:])
+	mirrorPath := path.Join(configuration.Mirror, urlHashString)
+
+	log.Debug("Looking for mirror of '%s' in directory '%s'.\n", url, mirrorPath)
+
+	if util.DirExists(mirrorPath) {
+		log.Debug("Mirror found at '%s'.\n", mirrorPath)
+		return &TarMirror{path: mirrorPath}, nil
+	}
+
+	util.MkdirAll(mirrorPath)
+	mod := TarModule{mirrorPath, nil}
+	if err := mod.download(url); err != nil {
+		// If downloading fails, we remove the mirror path to leave a clean tree so that the
+		// operation can be retried.
+		util.RemoveDir(mod.path)
+		return nil, err
+	}
+	log.Debug("Mirror downloaded at '%s'.\n", mirrorPath)
+
+	return &TarMirror{path: mirrorPath}, nil
+}
+
 // createTarModule creates a new TarModule in the given `modulePath` by downloading
 // and extracting the TAR archive reference by `url`. The origin of the module
 // (i.e., the download url) is stored in a ".metadata" file inside the module directory.
 func createTarModule(modulePath, url string) (Module, error) {
-	log.Log("Downloading '%s'.\n", url)
-
-	response, err := http.Get(url)
+	mirror, err := getOrCreateTarMirror(url)
 	if err != nil {
-		return nil, fmt.Errorf("failed to download archive: %s", err)
+		return nil, err
 	}
-	defer response.Body.Close()
 
-	hasher := sha256.New()
-	gzFile := io.TeeReader(response.Body, hasher)
-
-	tarFile, err := gzip.NewReader(gzFile)
+	module := TarModule{path: modulePath, mirror: mirror}
+	err = module.clone(url)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decompress: %s", err)
+		return nil, err
 	}
 
-	tarReader := tar.NewReader(tarFile)
-	tarRootDir := ""
-	for {
-		header, err := tarReader.Next()
-
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return nil, fmt.Errorf("failed to decompress: %s", err)
-		}
-
-		headerRootDir := getRoot(header.Name)
-		if header.Typeflag != tar.TypeDir && headerRootDir == header.Name {
-			return nil, fmt.Errorf("failed to decompress: archive can't have files outside root directory")
-		}
-		if tarRootDir == "" {
-			tarRootDir = headerRootDir
-		} else if tarRootDir != headerRootDir {
-			return nil, fmt.Errorf("failed to decompress: archive can't have more than one root directory")
-		}
-
-		// We can't assume that tarReader visits a dir before the files inside it, although this is true most of the time.
-		// So if we find a file whose dir hasn't been created yet, we make it, with a sensible default access mode
-		// When we eventually visit it, we set the correct mode
-		switch header.Typeflag {
-		case tar.TypeDir:
-			dirPath := path.Join(modulePath, stripRoot(header.Name))
-			log.Debug("Creating directory '%s'.\n", dirPath)
-			if err := os.MkdirAll(dirPath, os.FileMode(header.Mode)); err != nil {
-				return nil, fmt.Errorf("failed to create directory: %s", err)
-			}
-			// We need this again because if the dir already existed os.MkdirAll does nothing
-			if err := os.Chmod(dirPath, os.FileMode(header.Mode)); err != nil {
-				return nil, fmt.Errorf("failed to change filemode: %s", err)
-			}
-		case tar.TypeReg:
-			filePath := path.Join(modulePath, stripRoot(header.Name))
-			if err := os.MkdirAll(path.Dir(filePath), defaultDirMode); err != nil {
-				return nil, fmt.Errorf("failed to create directory: %s", err)
-			}
-			log.Debug("Creating file '%s'.\n", filePath)
-			file, err := os.Create(filePath)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create file: %s", err)
-			}
-			_, err = io.Copy(file, tarReader)
-			file.Close()
-			if err != nil {
-				return nil, fmt.Errorf("failed to write file: %s", err)
-			}
-			if err := os.Chmod(filePath, os.FileMode(header.Mode)); err != nil {
-				return nil, fmt.Errorf("failed to change filemode: %s", err)
-			}
-		case tar.TypeLink:
-			if getRoot(header.Linkname) != tarRootDir {
-				return nil, fmt.Errorf("failed to decompress: archive can't have more than one root directory")
-			}
-			oldname := path.Join(modulePath, stripRoot(header.Linkname))
-			newname := path.Join(modulePath, stripRoot(header.Name))
-			if err := os.MkdirAll(path.Dir(newname), defaultDirMode); err != nil {
-				return nil, fmt.Errorf("failed to create directory: %s", err)
-			}
-			log.Debug("Creating link from '%s' to '%s'.\n", newname, oldname)
-			if err = os.Link(oldname, newname); err != nil {
-				return nil, fmt.Errorf("failed to create link: %s", err)
-			}
-		case tar.TypeSymlink:
-			newname := path.Join(modulePath, stripRoot(header.Name))
-			if err := os.MkdirAll(path.Dir(newname), defaultDirMode); err != nil {
-				return nil, fmt.Errorf("failed to create directory: %s", err)
-			}
-			log.Debug("Creating symlink from '%s' to '%s'.\n", newname, header.Linkname)
-			if err := os.Symlink(header.Linkname, newname); err != nil {
-				return nil, fmt.Errorf("failed to create symlink: %s", err)
-			}
-
-		default:
-			return nil, fmt.Errorf("unknown tar type flag %d for entry '%s'", header.Typeflag, header.Name)
-		}
-	}
-
-	metadata := metadataFile{url, hex.EncodeToString(hasher.Sum(nil))}
-	util.WriteYaml(path.Join(modulePath, tarMetadataFileName), metadata)
-	return TarModule{modulePath}, nil
+	return module, err
 }
 
 func (m TarModule) RootPath() string {
@@ -200,4 +149,126 @@ func (m TarModule) Checkout(hash string) {
 	if hash != m.Head() {
 		log.Fatal("Failed to checkout version '%s': cannot change version of TarModule.\n", hash)
 	}
+}
+
+// clones a tar from either a mirror (if the tar module contains one and is valid) or downloaded from
+// the network
+func (m TarModule) clone(url string) error {
+	// Check if it is available already in the mirror
+	if m.mirror != nil {
+		// Validate the mirror by making sure the metadata path is present
+		metdata_path := path.Join(m.mirror.path, tarMetadataFileName)
+		if util.FileExists(metdata_path) {
+			err := util.CopyDirRecursively(m.mirror.path, m.path)
+			return err
+		}
+	}
+
+	// Mirror not available download instead
+	return m.download(url)
+}
+
+// Downloads a tar.gz gziped archive from the provided url
+func (m TarModule) download(url string) error {
+	log.Log("Downloading '%s'.\n", url)
+
+	response, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("failed to download archive: %s", err)
+	}
+	defer response.Body.Close()
+
+	hasher := sha256.New()
+	gzFile := io.TeeReader(response.Body, hasher)
+
+	tarFile, err := gzip.NewReader(gzFile)
+	if err != nil {
+		return fmt.Errorf("failed to decompress: %s", err)
+	}
+
+	tarReader := tar.NewReader(tarFile)
+	tarRootDir := ""
+	for {
+		header, err := tarReader.Next()
+
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("failed to decompress: %s", err)
+		}
+
+		headerRootDir := getRoot(header.Name)
+		if header.Typeflag != tar.TypeDir && headerRootDir == header.Name {
+			return fmt.Errorf("failed to decompress: archive can't have files outside root directory")
+		}
+		if tarRootDir == "" {
+			tarRootDir = headerRootDir
+		} else if tarRootDir != headerRootDir {
+			return fmt.Errorf("failed to decompress: archive can't have more than one root directory")
+		}
+
+		// We can't assume that tarReader visits a dir before the files inside it, although this is true most of the time.
+		// So if we find a file whose dir hasn't been created yet, we make it, with a sensible default access mode
+		// When we eventually visit it, we set the correct mode
+		switch header.Typeflag {
+		case tar.TypeDir:
+			dirPath := path.Join(m.path, stripRoot(header.Name))
+			log.Debug("Creating directory '%s'.\n", dirPath)
+			if err := os.MkdirAll(dirPath, os.FileMode(header.Mode)); err != nil {
+				return fmt.Errorf("failed to create directory: %s", err)
+			}
+			// We need this again because if the dir already existed os.MkdirAll does nothing
+			if err := os.Chmod(dirPath, os.FileMode(header.Mode)); err != nil {
+				return fmt.Errorf("failed to change filemode: %s", err)
+			}
+		case tar.TypeReg:
+			filePath := path.Join(m.path, stripRoot(header.Name))
+			if err := os.MkdirAll(path.Dir(filePath), defaultDirMode); err != nil {
+				return fmt.Errorf("failed to create directory: %s", err)
+			}
+			log.Debug("Creating file '%s'.\n", filePath)
+			file, err := os.Create(filePath)
+			if err != nil {
+				return fmt.Errorf("failed to create file: %s", err)
+			}
+			_, err = io.Copy(file, tarReader)
+			file.Close()
+			if err != nil {
+				return fmt.Errorf("failed to write file: %s", err)
+			}
+			if err := os.Chmod(filePath, os.FileMode(header.Mode)); err != nil {
+				return fmt.Errorf("failed to change filemode: %s", err)
+			}
+		case tar.TypeLink:
+			if getRoot(header.Linkname) != tarRootDir {
+				return fmt.Errorf("failed to decompress: archive can't have more than one root directory")
+			}
+			oldname := path.Join(m.path, stripRoot(header.Linkname))
+			newname := path.Join(m.path, stripRoot(header.Name))
+			if err := os.MkdirAll(path.Dir(newname), defaultDirMode); err != nil {
+				return fmt.Errorf("failed to create directory: %s", err)
+			}
+			log.Debug("Creating link from '%s' to '%s'.\n", newname, oldname)
+			if err = os.Link(oldname, newname); err != nil {
+				return fmt.Errorf("failed to create link: %s", err)
+			}
+		case tar.TypeSymlink:
+			newname := path.Join(m.path, stripRoot(header.Name))
+			if err := os.MkdirAll(path.Dir(newname), defaultDirMode); err != nil {
+				return fmt.Errorf("failed to create directory: %s", err)
+			}
+			log.Debug("Creating symlink from '%s' to '%s'.\n", newname, header.Linkname)
+			if err := os.Symlink(header.Linkname, newname); err != nil {
+				return fmt.Errorf("failed to create symlink: %s", err)
+			}
+
+		default:
+			return fmt.Errorf("unknown tar type flag %d for entry '%s'", header.Typeflag, header.Name)
+		}
+	}
+
+	metadata := metadataFile{url, hex.EncodeToString(hasher.Sum(nil))}
+	util.WriteYaml(path.Join(m.path, tarMetadataFileName), metadata)
+	return nil
 }

--- a/util/util.go
+++ b/util/util.go
@@ -137,13 +137,20 @@ func copyDirRecursivelyInner(sourceDir, destDir string, wg *sync.WaitGroup) erro
 			if err != nil {
 				return err
 			}
+
+			if err := os.Chmod(path.Join(destDir, fileInfo.Name()), fileInfo.Mode()); err != nil {
+				return err
+			}
 		} else {
 			wg.Add(1)
 
-			go func(source, dest string) {
+			go func(source, dest string, sourceFileInfo os.FileInfo) {
 				defer wg.Done()
 				CopyFile(source, dest)
-			}(path.Join(sourceDir, fileInfo.Name()), path.Join(destDir, fileInfo.Name()))
+				if err := os.Chmod(dest, sourceFileInfo.Mode()); err != nil {
+					log.Fatal("failed to change filemode: ", err)
+				}
+			}(path.Join(sourceDir, fileInfo.Name()), path.Join(destDir, fileInfo.Name()), fileInfo)
 		}
 	}
 


### PR DESCRIPTION
Given that builds often fail due to protocol errors during the download, keeping a local mirror should help to reduce how often those errors happen, as well as reduce the overall network traffic and time required to run the sync operations.

In order to use this mirror, a new user configuration file has been introduced, which is searched in the following directories by order of preference:
- `${DBT_CONFIG_DIR}/config.yaml` -- If `DBT_CONFIG_DIR` is set.
- `${XDG_CONFIG_HOME}/dbt/config.yaml` -- If `XDG_CONFIG_HOME` is set.
- `${HOME}/.config/dbt/config.yaml`

This file will contain a `Mirror` element that defines the location of the local mirror. If `Mirror` is empty or the configuration file does not exist, it falls back to the original behavior and does not attempt to create/use any mirrors for each repo.

However, if the mirror directory is set in the configuration file, repositories are downloaded first into the mirror (if they don't yet exist). This happens differently for git and tar.gz modules
- Git modules create the mirror using the `git clone --mirror` command. Then the actual repository sets up a reference to the mirror with `git clone --reference ${MIRROR_PATH}`. If the mirror already exists, only the new repository with the `--rerence` option is executed, reducing the number of git objects that need to be fetched from the network.
- Tar modules create the mirror by uncompressing and unpacking the archive into the mirror dir. Note that `SetupModule` is not run at this point. Then the contents are copied from the mirror directory to the repository directory. If the mirror already exists, only the copy is performed and no network access is required.

