### PR TITLE
Bump dbt to 1.3.2

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -16,7 +16,7 @@ import (
 
 // DbtVersion is the current version of DBT. The minor version
 // is also used as the MODULE file version.
-var DbtVersion = [3]uint{1, 3, 1}
+var DbtVersion = [3]uint{1, 3, 2}
 
 // ModuleFileName is the name of the file describing each module.
 const ModuleFileName = "MODULE"


### PR DESCRIPTION
Turns out there was a 1.3.1 release already but the version number was still at 1.3.0, so I need to bump it again.