### PR TITLE
git worktree support

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -42,7 +42,8 @@ func runSync(cmd *cobra.Command, args []string) {
 	log.Debug("Workspace: %s.\n", workspaceRoot)
 
 	workspaceModuleFile := module.ReadModuleFile(workspaceRoot)
-	workspaceModuleName := path.Base(workspaceRoot)
+	workspaceModuleName := module.OpenModule(workspaceRoot).Name()
+	log.Debug("Workspace module name: '%s\n", workspaceModuleName)
 
 	if workspaceModuleFile.Layout != "cpp" {
 		// Create the DEPS/ subdirectory and create a symlink to the top-level module.

--- a/module/git.go
+++ b/module/git.go
@@ -71,6 +71,10 @@ func CreateGitModule(modulePath, url string) (Module, error) {
 	return mod, nil
 }
 
+func (m GitModule) Name() string {
+	return strings.TrimSuffix(path.Base(m.URL()), ".git")
+}
+
 func (m GitModule) RootPath() string {
 	return m.path
 }

--- a/module/module.go
+++ b/module/module.go
@@ -36,6 +36,7 @@ type GoModule struct {
 
 // Module represents a checked-out module.
 type Module interface {
+	Name() string
 	URL() string
 
 	Head() string
@@ -301,6 +302,13 @@ func OpenModule(modulePath string) Module {
 
 	if util.DirExists(path.Join(modulePath, ".git")) {
 		log.Debug("Found '.git' directory. Expecting this to be a GitModule.\n")
+		module := GitModule{path: modulePath}
+		mirror, _ := getOrCreateGitMirror(module.URL())
+		return GitModule{path: modulePath, mirror: mirror}
+	}
+
+	if util.FileExists(path.Join(modulePath, ".git")) {
+		log.Debug("Found '.git' worktree file. Expecting this to be a GitModule.\n")
 		module := GitModule{path: modulePath}
 		mirror, _ := getOrCreateGitMirror(module.URL())
 		return GitModule{path: modulePath, mirror: mirror}

--- a/module/tar.go
+++ b/module/tar.go
@@ -104,6 +104,10 @@ func createTarModule(modulePath, url string) (Module, error) {
 	return module, err
 }
 
+func (m TarModule) Name() string {
+	return path.Base(m.RootPath())
+}
+
 func (m TarModule) RootPath() string {
 	return m.path
 }


### PR DESCRIPTION
git worktree enables the user to have several copies of a repo in different directories and in different states in order to support working on multiple branches in parallel. Currently, this does not work well with `dbt` as it expects the workspace directory to match the name of the module.

The purpose of this PR is to modify the `sync` command such that it will create a suitably named symlink in `DEPS/` named after the actual module name instead of merely being named after the top-level directory. The consequence is that `dbt` no longer requires that the workspace directory name matches that of the module.

Only tested with Git so far.