### PR TITLE
Add analyze command

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"github.com/daedaleanai/cobra"
+)
+
+var analyzeCmd = &cobra.Command{
+	Use:   "analyze [patterns] [build flags] [: test args]",
+	Short: "Builds the targets and generates static analysis reports.",
+	Long:  `Builds the targets and generates static analysis reports.`,
+	Run:   runAnalyze,
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return completeBuildArgs(toComplete, modeAnalyze), cobra.ShellCompDirectiveNoFileComp
+	},
+	DisableFlagsInUseLine: true,
+}
+
+func init() {
+	rootCmd.AddCommand(analyzeCmd)
+	analyzeCmd.Flags().SetInterspersed(false)
+}
+
+func runAnalyze(cmd *cobra.Command, args []string) {
+	testArgs := []string{}
+	buildArgs := args
+	for idx, arg := range args {
+		if arg == ":" {
+			testArgs = args[idx+1:]
+			buildArgs = args[:idx]
+			break
+		}
+	}
+	runBuild(buildArgs, modeAnalyze, testArgs)
+}


### PR DESCRIPTION
The idea behind this command is to avoid generating all analyzer rules every single time we run any dbt command.

In the future, caching the generator output is probably even nicer, but this is a lower hanging fruit that could easily be fixed to avoid paying the cost of sa-report targets if we are not attempting to use them.

Note that the second pass has not yet changed to be only run in coverage and analyze modes because it would be a backwards incompatible change.

Once all jobs are updated to use the new analyze command we can add that without breaking the jobs.