### PR TITLE
Fail build if multiple dbt modules provide the same BUILD.go file

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -553,11 +553,17 @@ func copyBuildAndRuleFiles(moduleName, modulePath, buildFilesDir string, modules
 		util.WriteFile(initFilePath, []byte(initFileContent))
 
 		copyFilePath := path.Join(goFilesDir, buildFile.CopyPath)
+		for util.FileExists(copyFilePath) {
+			log.Fatal("BUILD.go file provided by more than one dbt module: %s\n", copyFilePath)
+		}
 		util.CopyFile(buildFile.SourcePath, copyFilePath)
 	}
 
 	for _, ruleFile := range module.ListRules(modules[moduleName]) {
 		copyFilePath := path.Join(goFilesDir, ruleFile.CopyPath)
+		if util.FileExists(copyFilePath) {
+			log.Fatal("Rule file provided by more than one dbt module: %s\n", copyFilePath)
+		}
 		util.CopyFile(ruleFile.SourcePath, copyFilePath)
 	}
 

--- a/module/module.go
+++ b/module/module.go
@@ -56,12 +56,12 @@ func listGoModules(module Module, moduleFile ModuleFile) []GoModule {
 
 	deps := []string{}
 
-	for depName, _ := range moduleFile.Dependencies {
+	for depName := range moduleFile.Dependencies {
 		deps = append(deps, depName)
 	}
 
 	return []GoModule{
-		GoModule{
+		{
 			Name: moduleName,
 			Deps: deps,
 		},
@@ -74,7 +74,7 @@ func listGoModulesCpp(module Module, moduleFile ModuleFile) []GoModule {
 
 	deps := []string{}
 
-	for depName, _ := range moduleFile.Dependencies {
+	for depName := range moduleFile.Dependencies {
 		deps = append(deps, depName)
 	}
 


### PR DESCRIPTION
This can now happen because the dbt module and the Go module names are no longer tied in the CPP layout.

So far, when this has happened, one of the 2 files would be taken randomly (Because modules are part of a hash map which has random ordering in Go) and has non-repeatable behavior.

This makes it consistent so that as soon as a collision is detected, the operation is aborted and the user is notified.